### PR TITLE
Improve highlighting feedback

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -33,6 +33,11 @@ Config =
     type: 'integer'
     default: 100
     description: "Delay before triggering highlighting after selection has been modified (in ms)"
+  highlightSelectionExcludeUnique:
+    order: 9
+    type: 'boolean'
+    default: false
+    description: "Don't highlight selection if only one occurence found"
   displayCountOnStatusBar:
     order: 11
     type: 'boolean'
@@ -170,18 +175,19 @@ module.exports =
     @clearSelectionDecoration()
     return if @shouldExcludeEditor(editor)
     selection = editor.getLastSelection()
-    return unless @needToHighlightSelection(selection)
+    return unless @needToHighlightSelection(editor, selection)
     keyword = selection.getText()
     return unless scanRange = getVisibleBufferRange(editor)
     @selectionDecorations = @highlightKeyword(editor, scanRange, keyword, 'box-selection')
 
-  needToHighlightSelection: (selection) ->
+  needToHighlightSelection: (editor, selection) ->
     switch
       when (not getConfig('highlightSelection'))
           , selection.isEmpty()
           , not selection.getBufferRange().isSingleLine()
           , selection.getText().length < getConfig('highlightSelectionMinimumLength')
           , allWhiteSpaceRegExp.test(selection.getText())
+          , getConfig('highlightSelectionExcludeUnique') and @getCountForKeyword(editor, selection.getText()) <= 1
         false
       else
         true

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,7 +10,7 @@ Config =
     type: 'string'
     default: 'box'
     enum: ['box', 'highlight']
-    description: "Decoation style for highlight"
+    description: "Decoration style for highlight"
   highlightSelection:
     order: 5
     type: 'boolean'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -28,6 +28,11 @@ Config =
     default: [
       'vim-mode-plus.visual-mode.blockwise',
     ]
+  highlightSelectionThrottle:
+    order: 8
+    type: 'integer'
+    default: 100
+    description: "Delay before triggering highlighting after selection has been modified (in ms)"
   displayCountOnStatusBar:
     order: 11
     type: 'boolean'
@@ -80,6 +85,8 @@ getVisibleEditor = ->
 
 getConfig = (name) ->
   atom.config.get "quick-highlight.#{name}"
+observeConfig = (name, callback) ->
+  atom.config.observe "quick-highlight.#{name}", callback
 
 getVisibleBufferRange = (editor) ->
   editorElement = getView(editor)
@@ -122,7 +129,10 @@ module.exports =
       # So we separately need to cover this case from Atom v1.1.0
       editorSubs.add editorElement.onDidAttach => @refreshEditor(editor)
 
-      debouncedhighlightSelection = _.debounce(@highlightSelection.bind(this), 100)
+      debouncedhighlightSelection = null
+      subs.add observeConfig 'highlightSelectionThrottle', (delay) =>
+        debouncedhighlightSelection = _.debounce(@highlightSelection.bind(this), delay)
+
       editorSubs.add editor.onDidChangeSelectionRange ({selection}) ->
         debouncedhighlightSelection(editor) if selection.isLastSelection()
       editorSubs.add editorElement.onDidChangeScrollTop => @highlightSelection(editor)

--- a/spec/quick-highlight-spec.coffee
+++ b/spec/quick-highlight-spec.coffee
@@ -250,6 +250,25 @@ describe "quick-highlight", ->
       expect(editor.getLastSelection().isEmpty()).toBe false
       expect(getDecorations(editor)).toHaveLength 0
 
+    describe "when highlightSelectionExcludeUnique is set", ->
+      beforeEach ->
+        setConfig('highlightSelectionExcludeUnique', true)
+        editor.setText """
+          orange not
+          orange
+          """
+
+      it "won't decorate when only one occurence of selection is found", ->
+        dispatchCommand('editor:select-to-end-of-line')
+        expect(editor.getSelectedText()).toBe 'orange not'
+        advanceClock(150)
+        expect(getDecorations(editor)).toHaveLength 0
+
+      it "will decorate multiple occurences of selection", ->
+        dispatchCommand('editor:select-word')
+        advanceClock(150)
+        expect(editor).toHaveDecorations length: 2, color: 'selection', text: 'orange'
+
     it "won't decorate when highlightSelection is disabled", ->
       setConfig('highlightSelection', false)
       dispatchCommand('editor:select-word')


### PR DESCRIPTION
Tried to improve a bit highlight-on-fly feature:
- Omit highlighting selection if there are no other occurences of it in text buffer. Useful when buffer spans multiple pages. Made this available as  `highlightSelectionExcludeUnique` config option.
- Constant delay of 100ms before highlighting after changing selection perceived really slow, as compared to default selection marker. I've just refactored that delay into `highlightSelectionThrottle` setting to allow modifying it with ease.
